### PR TITLE
Bump log4j-core from 2.3 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <struts2.version>2.3.30</struts2.version>
-        <log4j2.version>2.3</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>3.0.5.RELEASE</spring.version>
     </properties>


### PR DESCRIPTION
Bumps log4j-core from 2.3 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production ...